### PR TITLE
Feat/use testnet faucet link

### DIFF
--- a/src/components/Panels/Faucet.vue
+++ b/src/components/Panels/Faucet.vue
@@ -82,15 +82,8 @@ export default {
       this.contractCode = undefined;
     },
     async handleRequest() {
-      // Defaults to Testnet faucet URL
-      let API_LINK = process.env.VUE_APP_TESTNET_FAUCET;
-      
-      // Simulated ENV
-      if (this.network.url === process.env.VUE_APP_ISOLATED_URL) {
-        // Reference: https://github.com/Zilliqa/zilliqa-isolated-server-faucet
-        API_LINK = process.env.VUE_APP_ISOLATED_FAUCET + "request-funds";
-      }
-
+      // Reference: https://github.com/Zilliqa/zilliqa-isolated-server-faucet
+      const API_LINK = process.env.VUE_APP_ISOLATED_FAUCET + "request-funds";
       return axios
         .post(API_LINK, {
           address: this.address,

--- a/src/components/TopBar/index.vue
+++ b/src/components/TopBar/index.vue
@@ -20,12 +20,13 @@
           </ul>
         </li>
         <explorer-link />
+        <testnet-wallet-link v-if="isTestnet" class="ml-3"/>
         <a
           href="#"
-          v-if="isTestnetOrIsolatedServer"
+          v-if="isIsolatedServer"
           @click="handleOpenFaucet"
           class="ml-3"
-        >Zilliqa Faucet</a>
+        >Faucet</a>
       </div>
       <div class="details d-flex">
         <account-balance />
@@ -41,6 +42,7 @@ import NetworkSelector from "./NetworkSelector";
 import AccountSelector from "./AccountSelector";
 import AccountBalance from "./AccountBalance";
 import ExplorerLink from "../UI/ExplorerLink";
+import TestnetWalletLink from "../UI/TestnetWalletLink";
 
 import { mapGetters } from "vuex";
 
@@ -51,15 +53,15 @@ export default {
     AccountSelector,
     AccountBalance,
     ExplorerLink,
+    TestnetWalletLink,
   },
   computed: {
     ...mapGetters("networks", { selectedNetwork: "selected" }),
-    isTestnetOrIsolatedServer() {
-      if (this.selectedNetwork.url !== "https://api.zilliqa.com") {
-        return true;
-      }
-
-      return false;
+    isIsolatedServer() {
+      return this.selectedNetwork.url === process.env.VUE_APP_ISOLATED_URL
+    },
+    isTestnet() {
+      return this.selectedNetwork.url === 'https://dev-api.zilliqa.com'
     },
   },
   methods: {

--- a/src/components/UI/TestnetWalletLink.vue
+++ b/src/components/UI/TestnetWalletLink.vue
@@ -1,0 +1,45 @@
+<template>
+  <a
+    :href="link"
+    target="_blank"
+    class="testnet-wallet-link"
+  >
+    <span>Faucet</span>
+  </a>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+
+export default {
+  name: "TestnetWalletLink",
+  computed: {
+    ...mapGetters("accounts", { account: "selected" }),
+    link() {
+      const testnetFaucetUrl = 'https://dev-wallet.zilliqa.com/faucet'
+      if (this.account && this.account.address) {
+        return testnetFaucetUrl+ `?address=${this.account.address}`
+      }
+      return testnetFaucetUrl
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+.address-container {
+  width: 100%;
+  color: #000;
+
+  &:hover {
+    text-decoration: none;
+    color: $primary;
+  }
+
+  .address {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+</style>

--- a/src/components/UI/TestnetWalletLink.vue
+++ b/src/components/UI/TestnetWalletLink.vue
@@ -10,6 +10,7 @@
 
 <script>
 import { mapGetters } from "vuex";
+import { toBech32Address } from "@zilliqa-js/crypto";
 
 export default {
   name: "TestnetWalletLink",
@@ -18,7 +19,8 @@ export default {
     link() {
       const testnetFaucetUrl = 'https://dev-wallet.zilliqa.com/faucet'
       if (this.account && this.account.address) {
-        return testnetFaucetUrl+ `?address=${this.account.address}`
+        const bech32Address = toBech32Address(this.account.address)
+        return testnetFaucetUrl+ `?address=${bech32Address}`
       }
       return testnetFaucetUrl
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR uses testnet wallet faucet link if testnet is selected.
This can make it more maintainable by reducing the complexity.

An example of href can be the following:
`https://dev-wallet.zilliqa.com/faucet?address=zil1xkfpmpthtdpqqfql7y3ksssrm7pkum9kyjcx9t`

https://user-images.githubusercontent.com/86328181/128125396-1398d5f9-f922-4b0f-9b81-1b2ba921037e.mov

The testnet wallet doesn't autofill the address yet but it will do in the upcoming release with https://github.com/Zilliqa/nucleus-wallet/pull/107.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress. -->

- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
