### PR TITLE
Fix/address calls

### DIFF
--- a/src/components/Inputs/ContractInput.vue
+++ b/src/components/Inputs/ContractInput.vue
@@ -13,7 +13,7 @@
       :class="{ 'has-errors': error }"
       ref="paramValue"
       @input="updateData"
-      v-if="inputType !== 'List' && inputType !== null"
+      v-if="inputType.parsed !== 'List' && inputType.parsed !== null"
     />
     <ace-editor
       :value="pvalue"

--- a/src/components/Inputs/ContractInput.vue
+++ b/src/components/Inputs/ContractInput.vue
@@ -13,7 +13,7 @@
       :class="{ 'has-errors': error }"
       ref="paramValue"
       @input="updateData"
-      v-if="inputType.parsed !== 'List' && inputType.parsed !== null"
+      v-if="(inputType && inputType !== 'List') || inputType === type"
     />
     <ace-editor
       :value="pvalue"

--- a/src/components/Panels/DeployContract.vue
+++ b/src/components/Panels/DeployContract.vue
@@ -1,20 +1,32 @@
 <template>
   <div class="panel-content">
     <div class="header">
-      <div class="title">Deploy {{file.name}}.scilla</div>
-      <img src="@/assets/close-color.svg" @click="handleClose" class="close-button-new" />
+      <div class="title">Deploy {{ file.name }}.scilla</div>
+      <img
+        src="@/assets/close-color.svg"
+        @click="handleClose"
+        class="close-button-new"
+      />
     </div>
     <div class="body p-4">
-      <div class="alert alert-info" v-if="abi === undefined">Loading contract ABI</div>
+      <div class="alert alert-info" v-if="abi === undefined">
+        Loading contract ABI
+      </div>
 
       <div class="deploy-form" v-if="abi && !signedTx">
-        <transaction-parameters v-on:input="onTransactionParameters"></transaction-parameters>
+        <transaction-parameters
+          v-on:input="onTransactionParameters"
+        ></transaction-parameters>
         <!-- Initialization parameters -->
         <div class="row mb-4">
           <div class="col-12">
             <p class="font-weight-bold">Initialization parameters</p>
           </div>
-          <div class="col-12 mb-4" v-for="param in abi.params" :key="param.vname">
+          <div
+            class="col-12 mb-4"
+            v-for="param in abi.params"
+            :key="param.vname"
+          >
             <contract-input
               :error="param.validationErrors"
               :vname="param.vname"
@@ -30,11 +42,18 @@
           <div class="col-12 mb-4" v-if="account.type === 'keystore'">
             <div>
               <label>Enter your passphrase</label>
-              <input type="password" v-model="passphrase" class="form-control" />
+              <input
+                type="password"
+                v-model="passphrase"
+                class="form-control"
+              />
             </div>
           </div>
           <div class="col-12 d-flex" v-if="!loading">
-            <button class="btn btn-light text-danger text-small mr-2" @click="resetComponent">
+            <button
+              class="btn btn-light text-danger text-small mr-2"
+              @click="resetComponent"
+            >
               <small>Reset</small>
             </button>
             <button class="btn btn-primary btn-block" @click="handleDeploy">
@@ -46,10 +65,10 @@
       </div>
 
       <div class="alert alert-info" v-if="loading">
-        {{loading}}
+        {{ loading }}
         <i class="fas fa-spin fa-spinner"></i>
       </div>
-      <div class="alert alert-danger" v-if="error">{{error}}</div>
+      <div class="alert alert-danger" v-if="error">{{ error }}</div>
 
       <div class="alert" v-if="signedTx">
         <p class="font-weight-bold">Transaction ID</p>
@@ -59,16 +78,24 @@
         <p class="font-weight-bold mt-4">Receipt</p>
         <div
           class="alert"
-          :class="{'alert-success': signedTx.receipt.success === true, 'alert-danger': signedTx.receipt.success === false}"
-          style="overflow-x:scroll;"
+          :class="{
+            'alert-success': signedTx.receipt.success === true,
+            'alert-danger': signedTx.receipt.success === false,
+          }"
+          style="overflow-x: scroll"
         >
           <vue-json-pretty :data="signedTx.receipt"></vue-json-pretty>
         </div>
       </div>
 
-      <div class="alert alert-danger" v-if="signedTx && signedTx.receipt.errors.length">
+      <div
+        class="alert alert-danger"
+        v-if="signedTx && signedTx.receipt.errors.length"
+      >
         <ul>
-          <li v-for="err in signedTx.receipt.errors[0]" :key="err">{{ possibleErrors[err] }}</li>
+          <li v-for="err in signedTx.receipt.errors[0]" :key="err">
+            {{ possibleErrors[err] }}
+          </li>
         </ul>
       </div>
     </div>
@@ -88,7 +115,7 @@ import { Zilliqa } from "@zilliqa-js/zilliqa";
 import { mapGetters } from "vuex";
 import axios from "axios";
 
-import { validateParams } from "@/utils/validation.js";
+import { validateParams, getParamType } from "@/utils/validation.js";
 import ZilPayMixin from "@/mixins/zilpay";
 
 const MAX_TRIES = 120;
@@ -164,9 +191,10 @@ export default {
         try {
           const txn = await this.zilliqa.blockchain.getTransaction(this.txId);
           if (txn.receipt) {
-            const contractAddress = await this.zilliqa.blockchain.getContractAddressFromTransactionID(
-              this.txId
-            );
+            const contractAddress =
+              await this.zilliqa.blockchain.getContractAddressFromTransactionID(
+                this.txId
+              );
             if (contractAddress.result) {
               this.loading = false;
               const contract = {
@@ -422,9 +450,15 @@ export default {
           // eslint-disable-next-line no-empty
         } catch (e) {}
 
+        const validatedType = getParamType({ type: item.type });
+
         return {
           vname: item.vname,
-          type: item.type,
+          type:
+            validatedType.parsed !== validatedType.initial &&
+            validatedType.parsed === "ByStr20"
+              ? validatedType.parsed
+              : item.type,
           value: val,
         };
       });

--- a/src/components/Panels/DeployContract.vue
+++ b/src/components/Panels/DeployContract.vue
@@ -115,7 +115,7 @@ import { Zilliqa } from "@zilliqa-js/zilliqa";
 import { mapGetters } from "vuex";
 import axios from "axios";
 
-import { validateParams, getParamType } from "@/utils/validation.js";
+import { validateParams } from "@/utils/validation.js";
 import ZilPayMixin from "@/mixins/zilpay";
 
 const MAX_TRIES = 120;
@@ -450,15 +450,11 @@ export default {
           // eslint-disable-next-line no-empty
         } catch (e) {}
 
-        const validatedType = getParamType({ type: item.type });
-
         return {
           vname: item.vname,
-          type:
-            validatedType.parsed !== validatedType.initial &&
-            validatedType.parsed === "ByStr20"
-              ? validatedType.parsed
-              : item.type,
+          type: item.type.includes("ByStr")
+            ? item.type.split(" ").shift()
+            : item.type,
           value: val,
         };
       });

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -19,8 +19,7 @@ const getParamType = ({ type }) => {
     const regex = /(?<List>List (.+))|(?<ByStr20>ByStr20)|(?<String>String)|(?<ByStr>ByStr)(\d{1,})?|(?<Uint>Uint)\d{1,}|(?<Int>Int)\d{1,}|(?<BNum>BNum)/;
 
     const res = type.match(regex);
-    let foundType = null;
-    let custom = false;
+    let foundType = undefined;
 
     if (res !== null) {
         const results = res.groups;
@@ -34,15 +33,10 @@ const getParamType = ({ type }) => {
 
         if (res[0] !== res.input) {
             foundType = res[0];
-            custom = true;
         }
     }
 
-    return {
-        initial: type,
-        parsed: foundType,
-        custom
-    };
+    return foundType
 }
 
 const validateParam = ({ type, value }) => {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -17,13 +17,13 @@ import { validation } from "@zilliqa-js/util";
 
 const getParamType = ({ type }) => {
     const regex = /(?<List>List (.+))|(?<ByStr20>ByStr20)|(?<String>String)|(?<ByStr>ByStr)(\d{1,})?|(?<Uint>Uint)\d{1,}|(?<Int>Int)\d{1,}|(?<BNum>BNum)/;
-    
+
     const res = type.match(regex);
     let foundType = null;
+    let custom = false;
 
     if (res !== null) {
         const results = res.groups;
-
 
         for (let key in results) {
             if (results[key] !== undefined) {
@@ -31,8 +31,18 @@ const getParamType = ({ type }) => {
                 break;
             }
         }
+
+        if (res[0] !== res.input) {
+            foundType = res[0];
+            custom = true;
+        }
     }
-    return foundType;
+
+    return {
+        initial: type,
+        parsed: foundType,
+        custom
+    };
 }
 
 const validateParam = ({ type, value }) => {


### PR DESCRIPTION
This PR fixes the issue that happens when deploying a contract that has init params that contain address values eg `ByStr20 with ... end` by replacing it with `ByStr20`.